### PR TITLE
Execution log

### DIFF
--- a/src/bench.ml
+++ b/src/bench.ml
@@ -115,10 +115,9 @@ let command =
                 | (None, Some args) -> build ~args ~verbose ~asm ()
                 | (Some compiler, None) -> build ~compiler ~verbose ~asm ()
                 | (Some compiler, Some args) -> build ~compiler ~args ~verbose ~asm () end
-            | Some "log" -> 
+            | Some "log" -> let tbl = Executioner.main () in 
               let print_kv k v = print_endline (k ^ ": " ^ (string_of_int v)) in 
-              let instructions = Executioner.parse_log "test.txt" in 
-                Hashtbl.iter print_kv (Executioner.execution_freq instructions)
+                Hashtbl.iter print_kv tbl 
             | None | Some _ -> print_endline "Please provide either build, spike-build, run, spike or clean as mode"
     )
 

--- a/src/bench.ml
+++ b/src/bench.ml
@@ -110,7 +110,10 @@ let command =
                 | (None, Some args) -> build ~args ~verbose ~asm ()
                 | (Some compiler, None) -> build ~compiler ~verbose ~asm ()
                 | (Some compiler, Some args) -> build ~compiler ~args ~verbose ~asm () end
-            | Some "log" -> List.iter (fun x -> print_endline (Riscv.instr_to_string x)) (Executioner.parse_log "test.txt")
+            | Some "log" -> 
+              let print_kv k v = print_endline (k ^ ": " ^ (string_of_int v)) in 
+              let instructions = Executioner.parse_log "test.txt" in 
+                Hashtbl.iter print_kv (Executioner.execution_freq instructions)
             | None | Some _ -> print_endline "Please provide either build, spike-build, run, spike or clean as mode"
     )
 

--- a/src/bench.ml
+++ b/src/bench.ml
@@ -1,5 +1,5 @@
 let helpers =
-  ["utils.ml"]
+  ["utils.ml"; "riscv.ml"; "executioner.ml"]
 
 let benchmarks = 
   ["intfloatarray.ml"; "sorting.ml"; "someornone.ml"; "zerotypes.ml"]
@@ -110,6 +110,7 @@ let command =
                 | (None, Some args) -> build ~args ~verbose ~asm ()
                 | (Some compiler, None) -> build ~compiler ~verbose ~asm ()
                 | (Some compiler, Some args) -> build ~compiler ~args ~verbose ~asm () end
+            | Some "log" -> List.iter (fun x -> print_endline (Riscv.instr_to_string x)) (Executioner.parse_log "test.txt")
             | None | Some _ -> print_endline "Please provide either build, spike-build, run, spike or clean as mode"
     )
 

--- a/src/bench.ml
+++ b/src/bench.ml
@@ -66,9 +66,9 @@ let run () =
   let executables = change_filetype ".out" benchmarks in
   List.iter (fun exec -> print_and_execute exec "./") executables
 
-let spike ?args:(args="") ?output:(output="results.txt") () = 
+let spike ?spikeargs:(spikeargs="") ?pkargs:(pkargs="") ?output:(output="results.txt") () = 
   let executables = change_filetype ".out" benchmarks in
-  let spike_instructions = List.map (fun exec -> "spike $pk " ^ args ^ " ./" ^ exec) executables in 
+  let spike_instructions = List.map (fun exec -> "spike" ^ spikeargs ^ "$pk " ^ pkargs ^ " ./" ^ exec) executables in 
     List.iter2 
       (fun exec -> fun sp -> 
         let cmd = ("echo \'" ^ print_header exec ^ "\' >> " ^ output ^ " && " ^ sp ^ " >> " ^ output ^ " && echo '\n'" ) in 
@@ -87,6 +87,7 @@ let command =
         and args     = flag "-args" (optional string) ~doc:"<argument-list> arguments to pass in"
         and verbose  = flag "-v" no_arg ~doc:" printing build commands etc."
         and spikearg = flag "-spike" (optional string) ~doc:"<argument-list> spike arguments"
+        and pkargs   = flag "-pk" (optional string) ~doc:"<argument-list> proxy kernel arguments"
         and asm      = flag "-asm" no_arg ~doc:" produces .s assembly files during the building phase"
         and output   = flag "-o" (optional string) ~doc:"filename where the results should be stored"
       in
@@ -95,11 +96,15 @@ let command =
             | Some "clean" -> clean ~verbose () 
             | Some "run"   -> run ()
             | Some "spike" ->
-              begin match (spikearg, output) with 
-                | (None, None)        -> spike ()
-                | (None, Some output) -> spike ~output ()
-                | (Some args, None)   -> spike ~args () 
-                | (Some args, Some output) -> spike ~args ~output () end
+              begin match (spikearg, pkargs, output) with 
+                | (None, None, None)        -> spike ()
+                | (None, None, Some output) -> spike ~output ()
+                | (None, Some pkargs, None) -> spike ~pkargs ()
+                | (None, Some pkargs, Some output) -> spike ~pkargs ~output ()
+                | (Some spikeargs, None, None)     -> spike ~spikeargs () 
+                | (Some spikeargs, None, Some output) -> spike ~spikeargs ~output () 
+                | (Some spikeargs, Some pkargs, None) -> spike ~pkargs ~spikeargs () 
+                | (Some spikeargs, Some pkargs, Some output) -> spike ~spikeargs ~pkargs ~output () end
             | Some "spike-build" -> 
               begin match (compiler, output) with 
                 | (Some compiler, Some output) -> build ~compiler ~args:"-ccopt -static" ~verbose:true ~asm:true ~outputc:true ~output ()

--- a/src/executioner.ml
+++ b/src/executioner.ml
@@ -2,11 +2,11 @@
 
 let open_file filename = 
   let ic = open_in filename in
-  let rec lines ic = 
+  let rec lines ic acc = 
   try 
     let line = input_line ic in  
-    line :: (lines ic) 
-  with End_of_file -> [] in lines ic          
+    lines ic (line::acc) 
+  with End_of_file -> List.rev acc in lines ic []         
 
 let parse_log log_file = 
   let lines = open_file log_file in 

--- a/src/executioner.ml
+++ b/src/executioner.ml
@@ -1,0 +1,13 @@
+(* Takes an execution log and makes sense of it *)
+
+let open_file filename = 
+  let ic = open_in filename in
+  let rec lines ic = 
+  try 
+    let line = input_line ic in  
+    line :: (lines ic) 
+  with End_of_file -> [] in lines ic          
+
+let parse_log log_file = 
+  let lines = open_file log_file in 
+  List.map (fun line -> Riscv.line_parse line) lines

--- a/src/executioner.ml
+++ b/src/executioner.ml
@@ -4,14 +4,14 @@ let open_file filename =
 
 let read_file ic chunk = 
   let rec lines ic acc = function 
-    | 0 -> (List.rev acc, ic)
+    | 0 -> (List.rev acc, ic, false)
     | n -> try let line = input_line ic in  
       lines ic (line::acc) (n - 1)
-  with End_of_file -> close_in ic; (List.rev acc, ic) in lines ic [] chunk       
+  with End_of_file -> close_in ic; (List.rev acc, ic, true) in lines ic [] chunk       
 
 let parse_log ic chunk = 
-  let (lines, nic) = read_file ic chunk in 
-    (Utils.map (fun line -> Riscv.line_parse line) lines, nic)
+  let (lines, nic, closed) = read_file ic chunk in 
+    (Utils.map (fun line -> Riscv.line_parse line) lines, nic, closed)
 
 let execution_freq freq_tbl log = 
   let rec loop = function 
@@ -19,7 +19,7 @@ let execution_freq freq_tbl log =
     | i::is -> 
       let instr = Riscv.instr_to_string i in 
       try let f = (Hashtbl.find freq_tbl instr) in
-        Hashtbl.add freq_tbl instr (f + 1); loop is
+        Hashtbl.replace freq_tbl instr (f + 1); loop is
       with Not_found -> Hashtbl.add freq_tbl instr 1; loop is in loop log
 
 (* Files are too big for memory - read in chuncks *)
@@ -27,6 +27,7 @@ let main () =
   let ic = open_file "test.txt" in
   let freq_tbl = Hashtbl.create 30 in 
   let rec loop in_c = 
-    let (log, nin_c) = parse_log in_c 100 in
-      execution_freq freq_tbl log; loop nin_c 
+    let (log, nin_c, closed) = parse_log in_c 100 in
+        if closed then freq_tbl else 
+        (execution_freq freq_tbl log; loop nin_c) 
   in loop ic

--- a/src/executioner.ml
+++ b/src/executioner.ml
@@ -1,23 +1,32 @@
 (* Takes an execution log and makes sense of it *)
+let open_file filename =
+  open_in filename 
 
-let open_file filename = 
-  let ic = open_in filename in
-  let rec lines ic acc = 
-  try 
-    let line = input_line ic in  
-    lines ic (line::acc) 
-  with End_of_file -> List.rev acc in lines ic []         
+let read_file ic chunk = 
+  let rec lines ic acc = function 
+    | 0 -> (List.rev acc, ic)
+    | n -> try let line = input_line ic in  
+      lines ic (line::acc) (n - 1)
+  with End_of_file -> close_in ic; (List.rev acc, ic) in lines ic [] chunk       
 
-let parse_log log_file = 
-  let lines = open_file log_file in 
-  Utils.map (fun line -> Riscv.line_parse line) lines
+let parse_log ic chunk = 
+  let (lines, nic) = read_file ic chunk in 
+    (Utils.map (fun line -> Riscv.line_parse line) lines, nic)
 
-let execution_freq log = 
-  let freq_tbl = Hashtbl.create 30 in 
+let execution_freq freq_tbl log = 
   let rec loop = function 
-    | []    -> freq_tbl
+    | []    -> ()
     | i::is -> 
       let instr = Riscv.instr_to_string i in 
       try let f = (Hashtbl.find freq_tbl instr) in
         Hashtbl.add freq_tbl instr (f + 1); loop is
       with Not_found -> Hashtbl.add freq_tbl instr 1; loop is in loop log
+
+(* Files are too big for memory - read in chuncks *)
+let main () =
+  let ic = open_file "test.txt" in
+  let freq_tbl = Hashtbl.create 30 in 
+  let rec loop in_c = 
+    let (log, nin_c) = parse_log in_c 100 in
+      execution_freq freq_tbl log; loop nin_c 
+  in loop ic

--- a/src/executioner.ml
+++ b/src/executioner.ml
@@ -10,4 +10,14 @@ let open_file filename =
 
 let parse_log log_file = 
   let lines = open_file log_file in 
-  List.map (fun line -> Riscv.line_parse line) lines
+  Utils.map (fun line -> Riscv.line_parse line) lines
+
+let execution_freq log = 
+  let freq_tbl = Hashtbl.create 30 in 
+  let rec loop = function 
+    | []    -> freq_tbl
+    | i::is -> 
+      let instr = Riscv.instr_to_string i in 
+      try let f = (Hashtbl.find freq_tbl instr) in
+        Hashtbl.add freq_tbl instr (f + 1); loop is
+      with Not_found -> Hashtbl.add freq_tbl instr 1; loop is in loop log

--- a/src/riscv.ml
+++ b/src/riscv.ml
@@ -6,8 +6,10 @@ type s_type = [`SW | `SH |`SD | `LB | `LW | `LD | `LBU | `LHU]
 type b_type = [`BEQ | `BNE | `BLT | `BGE | `BLTU | `BGEU]
 type u_type = [`LUI]
 type j_type = [`JAL | `JALR]
-type pseudo = [`SEXT_W | `MISC of string]
 
+type pure_instr = [r_type | i_type | s_type | b_type | u_type | j_type]
+
+type pseudo = [`SEXT_W | `MISC of string | `COMP of pure_instr]
 type insruction = [r_type | i_type | s_type | b_type | u_type | j_type | pseudo]
 
 type reg = string 
@@ -19,7 +21,7 @@ type i_type_instr = i_type * reg * reg * imm
 type s_type_instr = s_type * reg * offset * reg
 type b_type_instr = b_type * reg
 
-let instr_to_string = function
+let rec instr_to_string = function
   | `ADD  -> "add"
   | `LB   -> "lb"
   | `ADDI -> "addi"
@@ -54,9 +56,10 @@ let instr_to_string = function
   | `BLT  -> "blt"
   | `SW   -> "sw"
   | `SLT  -> "slt"
+  | `COMP instr -> "c." ^ (instr_to_string instr)
   | `MISC s -> s 
 
-let string_to_instr = function
+let rec string_to_instr = function
   | "add"  -> `ADD  
   | "lb"   -> `LB     
   | "addi" -> `ADDI 
@@ -91,7 +94,10 @@ let string_to_instr = function
   | "blt"  -> `BLT  
   | "sw"   -> `SW    
   | "slt"  -> `SLT
-  | s      ->  `MISC s
+  | s      ->  
+    let arr = Array.of_list (String.split_on_char '.' s) in 
+      if Array.length arr = 2 then `COMP (string_to_instr arr.(1))
+      else `MISC s
 
 (* Parsing a line of the log *)
 

--- a/src/riscv.ml
+++ b/src/riscv.ml
@@ -1,0 +1,104 @@
+(* All the RISC-V instructions *)
+
+type r_type = [`ADD | `SUB | `SLL | `SLT | `SLTU | `XOR | `SRL | `SRA | `OR | `AND]
+type i_type = [`ADDI | `SLTI | `SLTIU | `XORI | `ORI | `ANDI]
+type s_type = [`SW | `SH |`SD | `LB | `LW | `LD | `LBU | `LHU]
+type b_type = [`BEQ | `BNE | `BLT | `BGE | `BLTU | `BGEU]
+type u_type = [`LUI]
+type j_type = [`JAL | `JALR]
+type pseudo = [`SEXT_W | `MISC of string]
+
+type insruction = [r_type | i_type | s_type | b_type | u_type | j_type | pseudo]
+
+type reg = string 
+type offset = int
+type imm = int 
+
+type r_type_instr = r_type * reg * reg * reg
+type i_type_instr = i_type * reg * reg * imm
+type s_type_instr = s_type * reg * offset * reg
+type b_type_instr = b_type * reg
+
+let instr_to_string = function
+  | `ADD  -> "add"
+  | `LB   -> "lb"
+  | `ADDI -> "addi"
+  | `BEQ  -> "beq"
+  | `LW   -> "lw"
+  | `BLTU -> "bltu"
+  | `JALR -> "jalr"
+  | `BGE  -> "bge"
+  | `ORI  -> "ori"
+  | `SLTU -> "sltu"
+  | `XOR  -> "xor"
+  | `LHU  -> "lhu"
+  | `SLL  -> "sll"
+  | `SUB  -> "sub"
+  | `BNE  -> "bne"
+  | `SD   -> "sd"
+  | `BGEU -> "bgeu"
+  | `SLTIU -> "sltiu"
+  | `SH   -> "sh"
+  | `ANDI -> "andi"
+  | `XORI -> "xori"
+  | `SRL  -> "srl"
+  | `SRA  -> "sra"
+  | `SLTI -> "slti"
+  | `LD   -> "ld"
+  | `LBU  -> "lbu"
+  | `JAL  -> "jal"
+  | `LUI  -> "lui"
+  | `OR   -> "or"
+  | `AND  -> "and"
+  | `SEXT_W -> "sext.w"
+  | `BLT  -> "blt"
+  | `SW   -> "sw"
+  | `SLT  -> "slt"
+  | `MISC s -> s 
+
+let string_to_instr = function
+  | "add"  -> `ADD  
+  | "lb"   -> `LB     
+  | "addi" -> `ADDI 
+  | "beq"  -> `BEQ  
+  | "lw"   -> `LW
+  | "bltu" -> `BLTU
+  | "jalr" -> `JALR
+  | "bge"  -> `BGE  
+  | "ori"  -> `ORI  
+  | "sltu" -> `SLTU
+  | "xor"  -> `XOR  
+  | "lhu"  -> `LHU  
+  | "sll"  -> `SLL  
+  | "sub"  -> `SUB  
+  | "bne"  -> `BNE  
+  | "sd"   -> `SD     
+  | "bgeu" -> `BGEU
+  | "sltiu" ->`SLTIU
+  | "sh"   -> `SH     
+  | "andi" -> `ANDI
+  | "xori" -> `XORI
+  | "srl"  -> `SRL  
+  | "sra"  -> `SRA  
+  | "slti" -> `SLTI
+  | "ld"   -> `LD     
+  | "lbu"  -> `LBU  
+  | "jal"  -> `JAL  
+  | "lui"  -> `LUI  
+  | "or"   -> `OR     
+  | "and"  -> `AND  
+  | "sext.w" -> `SEXT_W
+  | "blt"  -> `BLT  
+  | "sw"   -> `SW    
+  | "slt"  -> `SLT
+  | s      ->  `MISC s
+
+(* Parsing a line of the log *)
+
+let line_parse line = 
+  let arr = Array.of_list (String.split_on_char ' ' line) in 
+  if Array.length arr >= 7 then 
+    (string_to_instr arr.(6))
+  else 
+    `MISC "" 
+    


### PR DESCRIPTION
Adds logging capabilities to the benchmarks for RISC-V. Typical workflow may look like the following. 

```
dune exec -- ./bench.exe spike-build -c /riscv-ocaml/bin/ocamlopt -o "results.txt" 
spike -l $pk sorting.out 2>&1 | tee test.txt
dune exec -- ./bench.exe log -log csv 
```

This will produce a CSV file which (as of this merge) will have the following format: 

```
instruction, freq
c.addi, 3
beqz, 45
....
```

🐫 + 📜